### PR TITLE
Hotfix / username changes result in duplication

### DIFF
--- a/src/main/java/de/aservo/ldap/adapter/api/directory/NestedDirectoryBackend.java
+++ b/src/main/java/de/aservo/ldap/adapter/api/directory/NestedDirectoryBackend.java
@@ -128,6 +128,16 @@ public interface NestedDirectoryBackend
     }
 
     /**
+     * To keep the cache up-to-date an user entity is updated or inserted.
+     * The user inherits the groups of another user
+     *
+     * @param id the user ID
+     * @param idOther the user ID of an existing user
+     */
+    default void upsertUser(String id, String idOther) {
+    }
+
+    /**
      * To keep the cache up-to-date all user entities are updated or inserted.
      *
      * @param startIndex the start index for pagination

--- a/src/main/java/de/aservo/ldap/adapter/backend/CachedWithPersistenceDirectoryBackend.java
+++ b/src/main/java/de/aservo/ldap/adapter/backend/CachedWithPersistenceDirectoryBackend.java
@@ -378,6 +378,25 @@ public class CachedWithPersistenceDirectoryBackend
     }
 
     @Override
+    public void upsertUser(String id, String idOther) {
+
+        super.upsertUser(id, idOther);
+
+        upsertUser(id);
+
+        QueryDefFactory factory = getCurrentQueryDefFactory();
+
+        getDirectGroupsOfUser(idOther).forEach(group -> {
+
+            factory
+                    .queryById("create_user_membership_if_not_exists")
+                    .on("parent_group_id", group.getName())
+                    .on("member_user_id", id)
+                    .execute(IgnoredResult.class);
+        });
+    }
+
+    @Override
     public int upsertAllUsers(int startIndex, int maxResults) {
 
         super.upsertAllUsers(startIndex, maxResults);

--- a/src/main/java/de/aservo/ldap/adapter/backend/ProxyDirectoryBackend.java
+++ b/src/main/java/de/aservo/ldap/adapter/backend/ProxyDirectoryBackend.java
@@ -118,6 +118,12 @@ public abstract class ProxyDirectoryBackend
     }
 
     @Override
+    public void upsertUser(String id, String idOther) {
+
+        directoryBackend.upsertUser(id, idOther);
+    }
+
+    @Override
     public int upsertAllUsers(int startIndex, int maxResults) {
 
         return directoryBackend.upsertAllUsers(startIndex, maxResults);


### PR DESCRIPTION
Because usernames are used as ID (primary key) the username cannot be changed.
The workaround:

1. Detect username change
2. Create new user
3. Assign groups from the old user to the new one
4. Delete old user