### PR TITLE
Add high availability to sync job

### DIFF
--- a/etc/backend.properties
+++ b/etc/backend.properties
@@ -67,5 +67,20 @@ persistence.apply-native-sql=false
 # use materialized views
 persistence.use-materialized-views=false
 
+# AcquireDbLock wait time, how long in seconds will the function in total try to get the lock
+persistence.acquiredblock-wait-time = 5
+# how many seconds shall AcquireDbLock wait between two tries
+persistence.acquiredblock-recheck-time = 1
+
 # pass only active users
 persistence.pass-active-users-only=true
+
+# set initial delay for sync-job in seconds
+mirror.sync.initialdelay = 3
+# set period for sync-job in seconds
+mirror.sync.period = 4
+ 
+# enable postgres dblock for corwd-sync so that only one of <n> instances executes the syncjob
+mirror.sync.usebdlock=false
+mirror.sync.lockid=123456
+

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>de.aservo</groupId>
     <artifactId>ldap-crowd-adapter</artifactId>
-    <version>7.1.0</version>
+    <version>7.2.0</version>
 
     <scm>
         <connection>scm:git:https://github.com/aservo/ldap-crowd-adapter.git</connection>

--- a/src/main/java/de/aservo/ldap/adapter/api/directory/NestedDirectoryBackend.java
+++ b/src/main/java/de/aservo/ldap/adapter/api/directory/NestedDirectoryBackend.java
@@ -209,4 +209,21 @@ public interface NestedDirectoryBackend
      * @return the cursor with membership elements
      */
     MappableCursor<MembershipEntity> getMemberships();
+
+    /**
+     * try to acquire a databaselock
+     *
+     * @return the boolean
+     */
+    default boolean acquireDbLock(int lockId) {
+
+        return false;
+    }
+
+    /**
+     * releases a databaselock
+     */
+    default void releaseDbLock(int lockId) {
+    }
+
 }

--- a/src/main/java/de/aservo/ldap/adapter/sql/impl/Executor.java
+++ b/src/main/java/de/aservo/ldap/adapter/sql/impl/Executor.java
@@ -118,13 +118,12 @@ public class Executor {
                 Result concreteResult;
 
                 if (query != null) {
-
                     setValues(statement, query.getBindValues());
-
                 } else {
-                    // TODO: support parameters for native SQL statements
+                    setValues(statement, parameters);
                 }
 
+                logger.debug("Native SQL for Statement: {}", statement);
                 statement.execute();
 
                 if (clazz == IgnoredResult.class) {
@@ -365,6 +364,17 @@ public class Executor {
 
             key++;
             setValue(statement, key, x);
+        }
+    }
+
+    private void setValues(PreparedStatement statement, Map<String, Object> parameters)
+            throws SQLException {
+
+        int key = 0;
+
+        for (var x : parameters.entrySet()) {
+            key++;
+            setValue(statement, key, x.getValue());
         }
     }
 

--- a/src/main/resources/de/aservo/ldap/adapter/db/queries.sql
+++ b/src/main/resources/de/aservo/ldap/adapter/db/queries.sql
@@ -230,3 +230,9 @@ NATIVE_SQL:refresh materialized view concurrently _Group_Membership_Transitive
 
 --[ID: refresh_materialized_view_for_transitive_user_memberships]--
 NATIVE_SQL:refresh materialized view concurrently _User_Membership_Transitive
+
+--[ID: pg_acquireLock]--
+NATIVE_SQL:SELECT pg_try_advisory_lock(?)
+
+--[ID: pg_releaseLock]--
+NATIVE_SQL:SELECT pg_advisory_unlock(?)


### PR DESCRIPTION
For high availability or multiple instance support the sync job has to be extended so that it always runs only on  one instance. These new config parameters were introduced:

set initial delay for sync-job in seconds
mirror.sync.initialdelay
set period for sync-job in seconds
mirror.sync.period
enable postgres dblock for corwd-sync so that only one of <n> instances executes the syncjob mirror.sync.usebdlock=
mirror.sync.lockid=
AcquireDbLock wait time, how long in seconds will the function in total try to get the lock persistence.acquiredblock-wait-time
how many seconds shall AcquireDbLock wait between two tries persistence.acquiredblock-recheck-time