### PR TITLE
Fix/34 sync db lock is not released

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>de.aservo</groupId>
     <artifactId>ldap-crowd-adapter</artifactId>
-    <version>7.2.0</version>
+    <version>7.2.1</version>
 
     <scm>
         <connection>scm:git:https://github.com/aservo/ldap-crowd-adapter.git</connection>

--- a/src/main/java/de/aservo/ldap/adapter/api/database/QueryDef.java
+++ b/src/main/java/de/aservo/ldap/adapter/api/database/QueryDef.java
@@ -51,4 +51,12 @@ public interface QueryDef {
      * @return the result set
      */
     <T extends Result> T execute(Class<T> clazz);
+
+    /**
+     * Executes a query with autocommit on.
+     *
+     * @param clazz the type of the expected result set
+     * @return the result set
+     */
+    <T extends Result> T executeWithAutoCommit(Class<T> clazz);
 }

--- a/src/main/java/de/aservo/ldap/adapter/backend/CachedWithPersistenceDirectoryBackend.java
+++ b/src/main/java/de/aservo/ldap/adapter/backend/CachedWithPersistenceDirectoryBackend.java
@@ -810,9 +810,15 @@ public class CachedWithPersistenceDirectoryBackend
         boolean unlocked = false;
         QueryDefFactory factory = getCurrentQueryDefFactory();
 
-        unlocked = Boolean.TRUE.equals(factory.queryById("pg_releaseLock").on("lock_id", lockId).execute(SingleResult.class).transform(this::mapReleaseDbLockResult));
-        if (!unlocked) {
-            logger.warn("Release of sync dblock failed, probably lock no longer exists.");
+        try {
+            unlocked = Boolean.TRUE.equals(factory.queryById("pg_releaseLock").on("lock_id", lockId).executeWithAutoCommit(SingleResult.class).transform(this::mapReleaseDbLockResult));
+            if (!unlocked) {
+                logger.warn("Release of sync dblock failed, probably lock no longer exists.");
+            } else {
+                logger.info("syncdblock released.");
+            }
+        } catch (Exception e) {
+            logger.error("An error occurred when releasing the syncdblock", e);
         }
     }
 

--- a/src/main/java/de/aservo/ldap/adapter/backend/MirroredCrowdDirectoryBackend.java
+++ b/src/main/java/de/aservo/ldap/adapter/backend/MirroredCrowdDirectoryBackend.java
@@ -369,12 +369,7 @@ public class MirroredCrowdDirectoryBackend
                     logger.error("An error occurred during synchronization.", e);
                 } finally {
                     if (syncUseDblock && gotLock) {
-                        try {
-                            directoryBackend.releaseDbLock(this.syncLockId);
-                            logger.info("syncdblock released.");
-                        } catch (Exception f) {
-                            logger.error("An error occurred when releasing the syncdblock.", f);
-                        }
+                        directoryBackend.releaseDbLock(this.syncLockId);
                     }
                 }
             });

--- a/src/main/java/de/aservo/ldap/adapter/sql/impl/Executor.java
+++ b/src/main/java/de/aservo/ldap/adapter/sql/impl/Executor.java
@@ -779,6 +779,26 @@ public class Executor {
             }
         }
 
+        public <T extends Result> T executeWithAutoCommit(Class<T> clazz) {
+
+            try {
+
+                boolean commitState = Executor.this.connection.getAutoCommit();
+                Executor.this.connection.setAutoCommit(true);
+                Object result;
+                if (byId)
+                     result= Executor.this.executeById(clauseOrId, parameters, clazz);
+                else
+                    result= Executor.this.execute(clauseOrId, parameters, clazz);
+                Executor.this.connection.setAutoCommit(commitState);
+                return (T) result;
+
+            } catch (SQLException e) {
+
+                throw new UncheckedSQLException(e);
+            }
+        }
+
         @Override
         public boolean equals(Object that) {
 


### PR DESCRIPTION
release db lock is now in separate transaction (with autocommit) so a rollback in sync does not prevent releasing the lock.