### PR TITLE
Remove duplicate crowd rest client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>de.aservo</groupId>
     <artifactId>ldap-crowd-adapter</artifactId>
-    <version>7.2.1</version>
+    <version>7.2.2</version>
 
     <scm>
         <connection>scm:git:https://github.com/aservo/ldap-crowd-adapter.git</connection>
@@ -166,14 +166,9 @@
 
         <!-- Crowd dependencies -->
         <dependency>
-            <groupId>com.atlassian.crowd.client</groupId>
-            <artifactId>atlassian-crowd-rest-client</artifactId>
-            <version>1.4</version>
-        </dependency>
-        <dependency>
             <groupId>com.atlassian.crowd</groupId>
             <artifactId>crowd-integration-client-rest</artifactId>
-            <version>4.2.3</version>
+            <version>4.4.5</version>
         </dependency>
         <dependency>
             <groupId>com.atlassian.security</groupId>


### PR DESCRIPTION
There are two rest clients in the pom.xml, which  worked in the past. But now in Azure environment an initialization error occurs: Caused by: java.lang.NoSuchMethodError: 'com.atlassian.crowd.service.client.AuthenticationMethod com.atlassian.crowd.service.client.ClientProperties.getAuthenticationMethod()'

This happens because two ClientProperties in the classpath exist but the wrong is chosen. This fix removes the old rest client lib from crowd.